### PR TITLE
Fix to support Magento CE 1.6 / EE 1.11.0.0

### DIFF
--- a/app/code/community/Shopgo/GTM/Block/Gtm.php
+++ b/app/code/community/Shopgo/GTM/Block/Gtm.php
@@ -95,7 +95,11 @@ class Shopgo_GTM_Block_Gtm extends Mage_Core_Block_Template
 			// Build products array.
 			foreach ($order->getAllVisibleItems() as $item) {
 				$product = $item->getProduct();
-				$product_categories = array();
+                                if (empty($product)) { // Covering for Magento CE 1.6 / EE 1.11.0.0
+                                    $product = Mage::getModel('catalog/product')->load($item->getProductId());
+                                }
+
+                                $product_categories = array();
 				try {
 					$product_categories = $product->getCategoryIds();
 				} catch (Mage_Exception $e) {


### PR DESCRIPTION
This patch checks to make sure getProduct() gets the product from the order item, and if not, to manually create the model. This allows Magento 1.6 and EE 1.11.0.0 to work with this module, as it causes a PHP fatal error.